### PR TITLE
chore: bump express from 4.18.2 to 4.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"clsx": "2.1.0",
 		"compression": "1.7.4",
 		"cross-env": "7.0.3",
-		"express": "4.18.2",
+		"express": "4.20.0",
 		"isbot": "5.1.0",
 		"morgan": "1.10.0",
 		"react": "18.2.0",


### PR DESCRIPTION
Summary of Changes
This PR updates the express package from version 4.18.2 to 4.20.0 to resolve a peer dependency conflict with @remix-run/express@2.13.1.

Error Report
While attempting to install dependencies, the following error was encountered:
```bash
npm resolution error report

While resolving: remix-shadcn@undefined
Found: express@4.18.2
node_modules/express
  express@"4.18.2" from the root project

Could not resolve dependency:
peer express@"^4.20.0" from @remix-run/express@2.13.1
node_modules/@remix-run/express
  @remix-run/express@"*" from the root project
```

This update ensures compatibility with the latest version of @remix-run/express.